### PR TITLE
docs(api-layer-readme): fix a typo in APILayer.md

### DIFF
--- a/APIlayer.md
+++ b/APIlayer.md
@@ -128,9 +128,9 @@ app.get("/trivia", async (req, res) => {
   const content = await response.json();
 
   // fail if db failed
-  if (data.response_code !== 0) {
+  if (content.response_code !== 0) {
     res.status(500);
-    res.send(`Open Trivia Database failed with internal response code ${data.response_code}`);
+    res.send(`Open Trivia Database failed with internal response code ${content.response_code}`);
     return;
   }
 


### PR DESCRIPTION
Change an unknown variable `data` to `content`

 It seems like it was a mistake; `data` isn't defined anywhere & the `content` variable has the `response_code` property, which is being used in the example.